### PR TITLE
Provide some directories also as terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ specfication http://www.freedesktop.org/wiki/Specifications/basedir-spec/.
         say $d;
     }
 
+    # Directories can be made available as terms as well
+    use XDG::BaseDirectory :terms;
+
+    say config-home;
+
 ```
 
 ## Description

--- a/lib/XDG/BaseDirectory.pm
+++ b/lib/XDG/BaseDirectory.pm
@@ -10,11 +10,16 @@ XDG::BaseDirectory - locate shared data and configuration
 
 =begin code
 
+    use XDG::BaseDirectory;
     my $bd = XDG::BaseDirectory.new
 
     for $bd.load-config-paths('mydomain.org', 'MyProg', 'Options') -> $d {
         say $d;
     }
+
+    # Directories can be made available as terms as well
+    use XDG::BaseDirectory :terms;
+    say config-home;
 
 =end code
 
@@ -273,4 +278,41 @@ take precedence over later ones.
         $resource;
     }
 }
+
+=begin pod
+
+=head2 Terms
+
+When XDG::BaseDirectory is C<use>d with the C<:terms> tag, the following
+properties of a generic XDG::BaseDirectory object are exported as eponymous
+terms:
+
+=item L<data-home>
+=item L<data-dirs>
+=item L<config-home>
+=item L<config-dirs>
+=item L<cache-home>
+=item L<runtime-dir>
+
+Example:
+
+=begin code
+
+    use XDG::BaseDirectory :terms;
+
+    say "Put config files into " ~ config-home ~ ", please.";
+
+=end code
+
+=end pod
+
+my constant $XDG = XDG::BaseDirectory.new;
+
+sub term:<data-home>   is export(:terms) { $XDG.data-home   }
+sub term:<data-dirs>   is export(:terms) { $XDG.data-dirs   }
+sub term:<config-home> is export(:terms) { $XDG.config-home }
+sub term:<config-dirs> is export(:terms) { $XDG.config-dirs }
+sub term:<cache-home>  is export(:terms) { $XDG.cache-home  }
+sub term:<runtime-dir> is export(:terms) { $XDG.runtime-dir }
+
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/004-terms.t
+++ b/t/004-terms.t
@@ -1,0 +1,11 @@
+use Test;
+use XDG::BaseDirectory :terms;
+
+plan 6;
+
+is data-home,   XDG::BaseDirectory.new.data-home,   'data-home is correct';
+is data-dirs,   XDG::BaseDirectory.new.data-dirs,   'data-dirs is correct';
+is config-home, XDG::BaseDirectory.new.config-home, 'config-home is correct';
+is config-dirs, XDG::BaseDirectory.new.config-dirs, 'config-dirs is correct';
+is cache-home,  XDG::BaseDirectory.new.cache-home,  'cache-home is correct';
+is runtime-dir, XDG::BaseDirectory.new.runtime-dir, 'runtime-dir is correct';


### PR DESCRIPTION
Useful base directories are now available as terms. If all you want
is the configuration directory `say XDG::BaseDirectory.new.config-home`
contains too much noise. With terms, it can be as short as
`say config-home`. Terms are only exported when XDG::BaseDirectory
is use'd with the :terms tag.